### PR TITLE
[DEV-260] Redis TTL 구현

### DIFF
--- a/src/main/kotlin/com/tiketeer/TiketeerWaiting/configuration/RedisConfig.kt
+++ b/src/main/kotlin/com/tiketeer/TiketeerWaiting/configuration/RedisConfig.kt
@@ -1,17 +1,26 @@
 package com.tiketeer.TiketeerWaiting.configuration
 
+
 import com.tiketeer.TiketeerWaiting.util.AspectUtils
+import com.tiketeer.TiketeerWaiting.util.RedisExpirationListener
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
+import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.core.RedisKeyValueAdapter
+import org.springframework.data.redis.listener.PatternTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.expression.spel.standard.SpelExpressionParser
 
+private val logger = KotlinLogging.logger {}
 @Configuration
 @Profile("!test")
 class RedisConfig {
@@ -34,5 +43,14 @@ class RedisConfig {
     @Bean
     fun redisTemplate(connectionFactory: ReactiveRedisConnectionFactory) : ReactiveRedisTemplate<String, String> {
         return ReactiveRedisTemplate(connectionFactory, RedisSerializationContext.string())
+    }
+
+    @Bean
+    fun redisMessageListenerContainer(connectionFactory: RedisConnectionFactory) : RedisMessageListenerContainer{
+        val listenerContainer = RedisMessageListenerContainer();
+        listenerContainer.setConnectionFactory(connectionFactory);
+//        listenerContainer.addMessageListener(expirationListener, PatternTopic("__keyevent@*__:expired"));
+        listenerContainer.setErrorHandler { e -> logger.error(e) { "There was an error in redis key expiration listener container" } };
+        return listenerContainer;
     }
 }

--- a/src/main/kotlin/com/tiketeer/TiketeerWaiting/configuration/RedisConfig.kt
+++ b/src/main/kotlin/com/tiketeer/TiketeerWaiting/configuration/RedisConfig.kt
@@ -49,7 +49,6 @@ class RedisConfig {
     fun redisMessageListenerContainer(connectionFactory: RedisConnectionFactory) : RedisMessageListenerContainer{
         val listenerContainer = RedisMessageListenerContainer();
         listenerContainer.setConnectionFactory(connectionFactory);
-//        listenerContainer.addMessageListener(expirationListener, PatternTopic("__keyevent@*__:expired"));
         listenerContainer.setErrorHandler { e -> logger.error(e) { "There was an error in redis key expiration listener container" } };
         return listenerContainer;
     }

--- a/src/main/kotlin/com/tiketeer/TiketeerWaiting/domain/waiting/usecase/GetRankAndTokenUseCase.kt
+++ b/src/main/kotlin/com/tiketeer/TiketeerWaiting/domain/waiting/usecase/GetRankAndTokenUseCase.kt
@@ -3,39 +3,54 @@ package com.tiketeer.TiketeerWaiting.domain.waiting.usecase
 import com.tiketeer.TiketeerWaiting.domain.ticketing.repository.TicketingRepository
 import com.tiketeer.TiketeerWaiting.domain.waiting.usecase.dto.GetRankAndTokenCommandDto
 import com.tiketeer.TiketeerWaiting.domain.waiting.usecase.dto.GetRankAndTokenResultDto
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.switchIfEmpty
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.UUID
-
+private val logger = KotlinLogging.logger {}
 @Service
 class GetRankAndTokenUseCase @Autowired constructor(private val redisTemplate: ReactiveRedisTemplate<String, String>, private val ticketingRepository: TicketingRepository) : GetRankAndToken {
     @Value("\${waiting.entry-size}")
     private lateinit var entrySize: Number
 
+    @Value("\${waiting.ttl}")
+    private lateinit var ttl: Number
+
+    @Value("\${waiting.entry-ttl}")
+    private lateinit var entryTtl: Number
+
     override fun getRankAndToken(dto: GetRankAndTokenCommandDto): Mono<GetRankAndTokenResultDto> {
         val currentTime = dto.entryTime
-        val token = generateToken(dto.email, dto.ticketingId)
-        val key = "queue::${dto.ticketingId}"
 
-        val validateResult = validateSalePeriod(dto.ticketingId, currentTime)
-        val mono = validateResult.flatMap { _ ->
-            redisTemplate.opsForZSet().rank(key, token)
-                .switchIfEmpty(
-                    redisTemplate.opsForZSet().add(key, token, currentTime.toDouble())
-                        .then(redisTemplate.opsForZSet().rank(key, token))
-                )
+        val key = "queue::${dto.ticketingId}"
+        val ttlKey = "ttl::${dto.ticketingId}::${dto.email}"
+
+        val validateMono = validateSalePeriod(dto.ticketingId, currentTime)
+        val redisMono = validateMono.flatMap { _ ->
+            redisTemplate.opsForValue().get(ttlKey)
+        }.flatMap {
+            redisTemplate.expire(ttlKey, Duration.ofMillis(ttl.toLong()))
+        }.switchIfEmpty {
+            logger.info{ "new redis token is added (ticketingId: ${dto.ticketingId}, email: ${dto.email})" }
+            redisTemplate.opsForValue().set(ttlKey, "",Duration.ofMillis(ttl.toLong()))
+                    .then(redisTemplate.opsForZSet().add(key, dto.email, currentTime.toDouble()))
+        }.flatMap { _ ->
+            redisTemplate.opsForZSet().rank(key, dto.email)
         }
 
-        val ret: Mono<GetRankAndTokenResultDto> = mono
+        val ret: Mono<GetRankAndTokenResultDto> = redisMono
             .flatMap { l ->
             if (l < entrySize.toInt()) {
+                redisTemplate.expire(ttlKey, Duration.ofMillis(entryTtl.toLong()))
                 Mono.just(GetRankAndTokenResultDto(l, generateToken(dto.email, dto.ticketingId)))
             } else {
                 Mono.just(GetRankAndTokenResultDto(l))

--- a/src/main/kotlin/com/tiketeer/TiketeerWaiting/domain/waiting/usecase/GetRankAndTokenUseCase.kt
+++ b/src/main/kotlin/com/tiketeer/TiketeerWaiting/domain/waiting/usecase/GetRankAndTokenUseCase.kt
@@ -50,7 +50,7 @@ class GetRankAndTokenUseCase @Autowired constructor(private val redisTemplate: R
         val ret: Mono<GetRankAndTokenResultDto> = redisMono
             .flatMap { l ->
             if (l < entrySize.toInt()) {
-                redisTemplate.expire(ttlKey, Duration.ofMillis(entryTtl.toLong()))
+                redisTemplate.expire(ttlKey, Duration.ofMillis(entryTtl.toLong())).subscribe()
                 Mono.just(GetRankAndTokenResultDto(l, generateToken(dto.email, dto.ticketingId)))
             } else {
                 Mono.just(GetRankAndTokenResultDto(l))

--- a/src/main/kotlin/com/tiketeer/TiketeerWaiting/util/RedisExpirationListener.kt
+++ b/src/main/kotlin/com/tiketeer/TiketeerWaiting/util/RedisExpirationListener.kt
@@ -3,20 +3,31 @@ package com.tiketeer.TiketeerWaiting.util;
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.data.redis.listener.KeyExpirationEventMessageListener
+import org.springframework.data.redis.listener.PatternTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.listener.Topic
 import org.springframework.stereotype.Component
 import org.springframework.util.ObjectUtils
 
 private val logger = KotlinLogging.logger {}
 
 @Component
-class RedisExpirationListener @Autowired constructor(private val redisTemplate: ReactiveRedisTemplate<String, String>, listenerContainer: RedisMessageListenerContainer) : KeyExpirationEventMessageListener(listenerContainer) {
+class RedisExpirationListener @Autowired constructor(private val redisTemplate: ReactiveRedisTemplate<String, String>, listenerContainer: RedisMessageListenerContainer) : MessageListener {
+	private final val keyEventExpiredTopic: Topic = PatternTopic("__keyevent@*__:expired")
 	private final val uuidPattern = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 	private final val emailPattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
 
-	override fun doHandleMessage(message: Message) {
+	init {
+		listenerContainer.addMessageListener(this, keyEventExpiredTopic)
+	}
+
+	override fun onMessage(message: Message, pattern: ByteArray?) {
+		if (ObjectUtils.isEmpty(message.channel) || ObjectUtils.isEmpty(message.body)) {
+			return
+		}
 		val ttlKey = String(message.body)
 		val regex = "^ttl::$uuidPattern::$emailPattern\$".toRegex()
 		if(regex.matches(ttlKey)){

--- a/src/main/kotlin/com/tiketeer/TiketeerWaiting/util/RedisExpirationListener.kt
+++ b/src/main/kotlin/com/tiketeer/TiketeerWaiting/util/RedisExpirationListener.kt
@@ -1,0 +1,30 @@
+package com.tiketeer.TiketeerWaiting.util;
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.stereotype.Component
+import org.springframework.util.ObjectUtils
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class RedisExpirationListener @Autowired constructor(private val redisTemplate: ReactiveRedisTemplate<String, String>, listenerContainer: RedisMessageListenerContainer) : KeyExpirationEventMessageListener(listenerContainer) {
+	private final val uuidPattern = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+	private final val emailPattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+
+	override fun doHandleMessage(message: Message) {
+		val ttlKey = String(message.body)
+		val regex = "^ttl::$uuidPattern::$emailPattern\$".toRegex()
+		if(regex.matches(ttlKey)){
+			val args = ttlKey.split("::")
+			val key = "queue::${args[1]}"
+			val token = args[2]
+			redisTemplate.opsForZSet().remove(key, token).subscribe { _ -> logger.debug { "expired key: $ttlKey" } }
+		}
+
+	}
+}

--- a/src/test/kotlin/com/tiketeer/TiketeerWaiting/configuration/EmbeddedRedisConfig.kt
+++ b/src/test/kotlin/com/tiketeer/TiketeerWaiting/configuration/EmbeddedRedisConfig.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
@@ -26,7 +27,8 @@ import java.io.IOException
 private val logger = KotlinLogging.logger {}
 
 @DisplayName("Embedded Redis 설정")
-@TestConfiguration
+@Configuration
+@Profile("test")
 class EmbeddedRedisConfig {
     @Value("\${spring.data.redis.host}")
     private lateinit var host: String

--- a/src/test/kotlin/com/tiketeer/TiketeerWaiting/domain/waiting/controller/WaitingControllerTest.kt
+++ b/src/test/kotlin/com/tiketeer/TiketeerWaiting/domain/waiting/controller/WaitingControllerTest.kt
@@ -22,7 +22,7 @@ import java.time.LocalDateTime
 import java.util.Date
 import java.util.UUID
 
-@Import(EmbeddedRedisConfig::class, TestHelper::class, R2dbcConfiguration::class)
+@Import(TestHelper::class, R2dbcConfiguration::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class WaitingControllerTest {
 	@Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,9 +8,10 @@ spring:
       repositories:
         enabled: false
       host: 127.0.0.1
-      port: 6379
-  redis:
-    maxmemory: 10
+      port: 6789
+      password: 1q2w3e4r@@Q
+      maxmemory: 10
+      notify-keyspace-events: Ex
 
 waiting:
   entry-size: 3

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,16 +9,18 @@ spring:
         enabled: false
       host: 127.0.0.1
       port: 6379
-      password: 1q2w3e4r@@Q
   redis:
     maxmemory: 10
 
 waiting:
   entry-size: 3
+  ttl: 6000
+  entry-ttl: 20000
 
 jwt:
   secret-key: 68895db81e621a83a1ab3d9892c24e8c6478bfe8b23fa47d324a54770c081630ed270acaf45b76456b36935c46cdffdba2d22bee94126b43a015f82c36333d3c
 
 logging:
   level:
+    ROOT: DEBUG
     org.springframework.r2dbc: DEBUG


### PR DESCRIPTION
- 작업 내용
  - ticketing_id + email 키로 TTL 등록
  - /waiting 요청 시 TTL 연장
  - expire 이벤트 Listener 등록
    - 이벤트 발생 시 Redis ZSet에서 ticketing_id, email로 멤버 엔트리 찾아 삭제